### PR TITLE
fix issue #85 - dragged idea displays only first letter

### DIFF
--- a/src/stores/StormStore.js
+++ b/src/stores/StormStore.js
@@ -164,7 +164,7 @@ function storeMovedIdea(idea) {
 * Create an idea group when an idea is dragged from the idea bank onto the workspace
 */
 function createIdeaGroup() {
-  const content = [lastMovedIdea.state.idea.content[0]];
+  const content = [lastMovedIdea.state.idea.content];
   _ideaGroups.push({content, keep: true});
 }
 /**


### PR DESCRIPTION
Fix: Ideas dragged into the workspace only displayed the first letter. Full idea is now displayed in the workspace.
