### PR TITLE
Issue 169 socket error handling

### DIFF
--- a/src/components/Idea.react.js
+++ b/src/components/Idea.react.js
@@ -20,9 +20,6 @@ const Idea = React.createClass({
       canDrag: false,
     };
   },
-  componentDidMount: function() {
-
-  },
   _onMouseDown: function() {
     const that = this;
     holdTimeout = setTimeout(function() {
@@ -126,10 +123,9 @@ const ideaSource = {
   },
   endDrag: function(props, monitor, component) {
     const dropped = monitor.didDrop();
-
     if (dropped) {
       StormActions.separateIdeas(
-        component.state.groupID,
+        component.props.groupID,
         component.props.content
       );
     }

--- a/src/stores/SocketStore.js
+++ b/src/stores/SocketStore.js
@@ -14,7 +14,7 @@ let currentBoardId = 0;
  * @param {function} func: callback function
  */
 function catchSocketError(res, func) {
-  if (!(res.error >= 400)) {
+  if (!(res.code >= 400)) {
     func(res);
   } else {
     console.error(res.message);


### PR DESCRIPTION
Fixes bug where adding a collection of 1 to a collection of 1 created previously causes an error when trying to remove the idea added ie
create collection of ["a"]
create collection of ["b"]
add "a" to be making ["b","a"]
removing "a" throws error from server and yields collections ["b","a"] and ["a"]
